### PR TITLE
✨ 添加 PR 作者信息支持

### DIFF
--- a/internal/api/gitee/client.go
+++ b/internal/api/gitee/client.go
@@ -367,6 +367,19 @@ func (c *Client) getPRList(ctx context.Context, repo string, token string) ([]mo
 			pr.State = models.PRStateClosed // 默认为 closed
 		}
 
+		// 解析作者信息
+		if userMap, ok := rawPR["user"].(map[string]interface{}); ok {
+			if login, ok := userMap["login"].(string); ok {
+				pr.Author.Login = login
+			}
+			if name, ok := userMap["name"].(string); ok {
+				pr.Author.Name = name
+			}
+			if email, ok := userMap["email"].(string); ok {
+				pr.Author.Email = email
+			}
+		}
+
 		prs = append(prs, pr)
 	}
 

--- a/internal/api/gitee/client_test.go
+++ b/internal/api/gitee/client_test.go
@@ -418,17 +418,27 @@ func TestGiteeClient_GetPRList_AuthorInfo(t *testing.T) {
 	t.Logf("  Email: %s", pr.Author.Email)
 	t.Logf("  PR State: %s", pr.State)
 
-	// 验证至少有 Login 字段（这是必需的）
-	if pr.Author.Login == "" {
-		t.Error("Expected PR to have author login, but got empty string")
+	// 验证第一个 PR 的固定数据（基于当前 API 返回的真实数据）
+	// OpenCloudOS/OpenCloudOS-Kernel 的第一个 PR（按创建时间倒序）的作者是 guzitao
+	expectedLogin := "guzitao"
+	if pr.Author.Login != expectedLogin {
+		t.Errorf("Expected first PR author login to be %s, but got %s", expectedLogin, pr.Author.Login)
 	}
 
-	// Name 和 Email 可能为空，只记录不报错
-	if pr.Author.Name == "" {
-		t.Log("⚠️  Author Name is empty (this might be normal)")
+	// Gitee 通常会返回 Name 字段
+	expectedName := "guzitao"
+	if pr.Author.Name != expectedName {
+		t.Errorf("Expected first PR author name to be %s, but got %s", expectedName, pr.Author.Name)
 	}
-	if pr.Author.Email == "" {
-		t.Log("⚠️  Author Email is empty (this might be normal)")
+
+	// Email 通常为空，只记录
+	if pr.Author.Email != "" {
+		t.Logf("Note: Author Email is not empty: %s (Gitee API usually doesn't return this)", pr.Author.Email)
+	}
+
+	// 验证 PR 状态也被正确解析
+	if pr.State == "" {
+		t.Error("Expected PR to have a state, but got empty string")
 	}
 }
 

--- a/internal/api/gitee/client_test.go
+++ b/internal/api/gitee/client_test.go
@@ -425,15 +425,15 @@ func TestGiteeClient_GetPRList_AuthorInfo(t *testing.T) {
 		t.Errorf("Expected first PR author login to be %s, but got %s", expectedLogin, pr.Author.Login)
 	}
 
-	// Gitee 通常会返回 Name 字段
+	// Gitee API 会返回 Name 字段
 	expectedName := "guzitao"
 	if pr.Author.Name != expectedName {
 		t.Errorf("Expected first PR author name to be %s, but got %s", expectedName, pr.Author.Name)
 	}
 
-	// Email 通常为空，只记录
+	// Gitee PR 列表 API 不返回 Email，应该为空
 	if pr.Author.Email != "" {
-		t.Logf("Note: Author Email is not empty: %s (Gitee API usually doesn't return this)", pr.Author.Email)
+		t.Errorf("Expected author email to be empty (Gitee API doesn't return it), but got %s", pr.Author.Email)
 	}
 
 	// 验证 PR 状态也被正确解析

--- a/internal/api/gitee/client_test.go
+++ b/internal/api/gitee/client_test.go
@@ -394,6 +394,44 @@ func TestGiteeClient_GetPRStats(t *testing.T) {
 	}
 }
 
+// TestGiteeClient_GetPRList_AuthorInfo 测试 PR 作者信息解析
+func TestGiteeClient_GetPRList_AuthorInfo(t *testing.T) {
+	client := NewClient()
+	ctx := context.Background()
+
+	// 使用 OpenCloudOS/OpenCloudOS-Kernel - 一个有很多 PR 的公开仓库
+	repo := "OpenCloudOS/OpenCloudOS-Kernel"
+
+	prs, _, err := client.getPRList(ctx, repo, "")
+	if err != nil {
+		t.Fatalf("Failed to get PR list: %v", err)
+	}
+
+	if len(prs) == 0 {
+		t.Fatal("No PRs found in test repository - this should not happen for OpenCloudOS/OpenCloudOS-Kernel")
+	}
+
+	pr := prs[0]
+	t.Logf("✅ Gitee PR Author Info:")
+	t.Logf("  Login: %s", pr.Author.Login)
+	t.Logf("  Name: %s", pr.Author.Name)
+	t.Logf("  Email: %s", pr.Author.Email)
+	t.Logf("  PR State: %s", pr.State)
+
+	// 验证至少有 Login 字段（这是必需的）
+	if pr.Author.Login == "" {
+		t.Error("Expected PR to have author login, but got empty string")
+	}
+
+	// Name 和 Email 可能为空，只记录不报错
+	if pr.Author.Name == "" {
+		t.Log("⚠️  Author Name is empty (this might be normal)")
+	}
+	if pr.Author.Email == "" {
+		t.Log("⚠️  Author Email is empty (this might be normal)")
+	}
+}
+
 // Helper function to check if string contains substring
 func contains(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {

--- a/internal/api/github/client.go
+++ b/internal/api/github/client.go
@@ -377,6 +377,19 @@ func (c *Client) getPRList(ctx context.Context, repo string, token string) ([]mo
 			pr.State = models.PRStateClosed
 		}
 
+		// 解析作者信息
+		if userMap, ok := rawPR["user"].(map[string]interface{}); ok {
+			if login, ok := userMap["login"].(string); ok {
+				pr.Author.Login = login
+			}
+			if name, ok := userMap["name"].(string); ok {
+				pr.Author.Name = name
+			}
+			if email, ok := userMap["email"].(string); ok {
+				pr.Author.Email = email
+			}
+		}
+
 		prs = append(prs, pr)
 	}
 

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -524,6 +524,110 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 	t.Logf("✅ Verified all 79 PRs (from oldest to newest): 68 by xgopilot[bot], 6 by luoliwoshang, 5 by MeteorsLiu")
 }
 
+// TestGitHubClient_GetPRList_AuthorInfo_HackathonGO 测试另一个仓库的 PR 作者信息解析
+func TestGitHubClient_GetPRList_AuthorInfo_HackathonGO(t *testing.T) {
+	client := NewClient()
+	ctx := context.Background()
+
+	// 使用 wwcchh0123/hackathonGO - 有 48 个 PR 的仓库
+	// API 返回顺序：从新到旧（newest first）
+	repo := "wwcchh0123/hackathonGO"
+
+	prs, _, err := client.getPRList(ctx, repo, "")
+	if err != nil {
+		t.Fatalf("Failed to get PR list: %v", err)
+	}
+
+	if len(prs) != 48 {
+		t.Fatalf("Expected 48 PRs, but got %d", len(prs))
+	}
+
+	t.Logf("Total PRs fetched: %d", len(prs))
+
+	// 反转数组，使其从旧到新排列
+	reversed := make([]models.PullRequest, len(prs))
+	for i, pr := range prs {
+		reversed[len(prs)-1-i] = pr
+	}
+
+	// 验证所有 48 个 PR 的作者信息（从旧到新的顺序）
+	// 包含 4 个真人用户：CarlJi (15个), minorcell (13个), wwcchh0123 (6个), 其余是 xgopilot[bot] (14个)
+	expectedAuthors := []string{
+		"xgopilot[bot]", // PR#4
+		"minorcell",     // PR#5
+		"xgopilot[bot]", // PR#8
+		"xgopilot[bot]", // PR#9
+		"wwcchh0123",    // PR#10
+		"wwcchh0123",    // PR#11
+		"CarlJi",        // PR#12
+		"CarlJi",        // PR#13
+		"CarlJi",        // PR#14
+		"minorcell",     // PR#15
+		"xgopilot[bot]", // PR#18
+		"xgopilot[bot]", // PR#19
+		"CarlJi",        // PR#20
+		"CarlJi",        // PR#21
+		"wwcchh0123",    // PR#24
+		"CarlJi",        // PR#25
+		"minorcell",     // PR#26
+		"minorcell",     // PR#27
+		"CarlJi",        // PR#28
+		"wwcchh0123",    // PR#29
+		"CarlJi",        // PR#31
+		"minorcell",     // PR#32
+		"xgopilot[bot]", // PR#35
+		"xgopilot[bot]", // PR#36
+		"xgopilot[bot]", // PR#39
+		"xgopilot[bot]", // PR#40
+		"minorcell",     // PR#41
+		"CarlJi",        // PR#42
+		"wwcchh0123",    // PR#43
+		"xgopilot[bot]", // PR#45
+		"CarlJi",        // PR#46
+		"minorcell",     // PR#47
+		"minorcell",     // PR#48
+		"CarlJi",        // PR#50
+		"xgopilot[bot]", // PR#53
+		"wwcchh0123",    // PR#55
+		"xgopilot[bot]", // PR#56
+		"minorcell",     // PR#57
+		"xgopilot[bot]", // PR#58
+		"CarlJi",        // PR#59
+		"xgopilot[bot]", // PR#60
+		"minorcell",     // PR#61
+		"minorcell",     // PR#62
+		"minorcell",     // PR#63
+		"CarlJi",        // PR#64
+		"CarlJi",        // PR#65
+		"CarlJi",        // PR#66
+		"CarlJi",        // PR#68
+	}
+
+	for i, pr := range reversed {
+		expected := expectedAuthors[i]
+
+		// 验证作者 Login 匹配预期
+		if pr.Author.Login != expected {
+			t.Errorf("PR index %d: Expected author to be %s, but got %s", i, expected, pr.Author.Login)
+		}
+
+		// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
+		if pr.Author.Name != "" {
+			t.Errorf("PR index %d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Name)
+		}
+		if pr.Author.Email != "" {
+			t.Errorf("PR index %d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Email)
+		}
+
+		// 验证 PR 状态
+		if pr.State == "" {
+			t.Errorf("PR index %d: Expected PR to have a state, but got empty string", i)
+		}
+	}
+
+	t.Logf("✅ Verified all 48 PRs (from oldest to newest): 15 by CarlJi, 13 by minorcell, 6 by wwcchh0123, 14 by xgopilot[bot]")
+}
+
 // Helper function to check if string contains substring
 func contains(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -395,7 +395,7 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 	ctx := context.Background()
 
 	// 使用 luoliwoshang/prompt-front-overflow - 有 79 个 PR 的仓库
-	// 测试最早的 22 个 PR（按创建时间正序）
+	// API 返回顺序：从新到旧（newest first）
 	repo := "luoliwoshang/prompt-front-overflow"
 
 	prs, _, err := client.getPRList(ctx, repo, "")
@@ -403,51 +403,68 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		t.Fatalf("Failed to get PR list: %v", err)
 	}
 
-	if len(prs) < 22 {
-		t.Fatalf("Expected at least 22 PRs, but got %d", len(prs))
+	if len(prs) < 79 {
+		t.Fatalf("Expected at least 79 PRs, but got %d", len(prs))
 	}
 
-	// getPRList 按创建时间倒序返回（最新的在前）
-	// 所以 prs[len-22:] 是最早的 22 个 PR
-	startIdx := len(prs) - 22
-	if startIdx < 0 {
-		startIdx = 0
+	t.Logf("Total PRs fetched: %d", len(prs))
+
+	// 测试最旧的 22 个 PR（在数组末尾）
+	// 这 22 个 PR 中：1 个是 luoliwoshang (PR#58)，21 个是 xgopilot[bot]
+	// 按照从旧到新的顺序：PR#11, #12, #17, #18, ..., #57, #58
+	oldest22 := prs[len(prs)-22:]
+
+	// 预期的作者（从旧到新）：最后一个是 luoliwoshang，前面 21 个是 bot
+	// 但在数组中，因为是倒序，所以第 0 个是 PR#58 (luoliwoshang)，后面是更旧的 bot PR
+	expectedAuthors := []string{
+		"luoliwoshang", // prs[57] = PR#58 (最旧的第 22 个)
+		"xgopilot[bot]", // prs[58] = PR#57
+		"xgopilot[bot]", // prs[59] = PR#55
+		"xgopilot[bot]", // prs[60] = PR#53
+		"xgopilot[bot]", // prs[61] = PR#52
+		"xgopilot[bot]", // prs[62] = PR#51
+		"xgopilot[bot]", // prs[63] = PR#49
+		"xgopilot[bot]", // prs[64] = PR#47
+		"xgopilot[bot]", // prs[65] = PR#38
+		"xgopilot[bot]", // prs[66] = PR#33
+		"xgopilot[bot]", // prs[67] = PR#31
+		"xgopilot[bot]", // prs[68] = PR#29
+		"xgopilot[bot]", // prs[69] = PR#28
+		"xgopilot[bot]", // prs[70] = PR#27
+		"xgopilot[bot]", // prs[71] = PR#25
+		"xgopilot[bot]", // prs[72] = PR#23
+		"xgopilot[bot]", // prs[73] = PR#20
+		"xgopilot[bot]", // prs[74] = PR#19
+		"xgopilot[bot]", // prs[75] = PR#18
+		"xgopilot[bot]", // prs[76] = PR#17
+		"xgopilot[bot]", // prs[77] = PR#12
+		"xgopilot[bot]", // prs[78] = PR#11 (最旧的第 1 个)
 	}
-	earliest22 := prs[startIdx:]
 
-	t.Logf("Total PRs: %d, testing earliest 22 PRs (index %d to %d)", len(prs), startIdx, len(prs)-1)
-
-	// 验证最早的 22 个 PR 的作者信息
-	// 第一个是 luoliwoshang (PR#58)，后面 21 个都是 xgopilot[bot]
-	expectedAuthors := make([]string, 22)
-	expectedAuthors[0] = "luoliwoshang"
-	for i := 1; i < 22; i++ {
-		expectedAuthors[i] = "xgopilot[bot]"
-	}
-
-	for i, pr := range earliest22 {
-		t.Logf("PR #%d Author: %s (expected: %s)", i, pr.Author.Login, expectedAuthors[i])
+	for i, pr := range oldest22 {
+		globalIdx := len(prs) - 22 + i
+		expected := expectedAuthors[i]
 
 		// 验证作者 Login 匹配预期
-		if pr.Author.Login != expectedAuthors[i] {
-			t.Errorf("PR #%d: Expected author login to be %s, but got %s", i, expectedAuthors[i], pr.Author.Login)
+		if pr.Author.Login != expected {
+			t.Errorf("Index %d: Expected author to be %s, but got %s", globalIdx, expected, pr.Author.Login)
 		}
 
 		// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
 		if pr.Author.Name != "" {
-			t.Errorf("PR #%d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Name)
+			t.Errorf("Index %d: Expected author name to be empty (GitHub API doesn't return it), but got %s", globalIdx, pr.Author.Name)
 		}
 		if pr.Author.Email != "" {
-			t.Errorf("PR #%d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Email)
+			t.Errorf("Index %d: Expected author email to be empty (GitHub API doesn't return it), but got %s", globalIdx, pr.Author.Email)
 		}
 
 		// 验证 PR 状态
 		if pr.State == "" {
-			t.Errorf("PR #%d: Expected PR to have a state, but got empty string", i)
+			t.Errorf("Index %d: Expected PR to have a state, but got empty string", globalIdx)
 		}
 	}
 
-	t.Logf("✅ Verified 22 earliest PRs: 1 by luoliwoshang, 21 by xgopilot[bot]")
+	t.Logf("✅ Verified 22 oldest PRs: 1 by luoliwoshang, 21 by xgopilot[bot]")
 }
 
 // Helper function to check if string contains substring

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -389,6 +389,44 @@ func TestGitHubClient_Platform(t *testing.T) {
 	}
 }
 
+// TestGitHubClient_GetPRList_AuthorInfo 测试 PR 作者信息解析
+func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
+	client := NewClient()
+	ctx := context.Background()
+
+	// 使用 goplus/llpkg - 一个中等规模的公开仓库
+	repo := "goplus/llpkg"
+
+	prs, _, err := client.getPRList(ctx, repo, "")
+	if err != nil {
+		t.Fatalf("Failed to get PR list: %v", err)
+	}
+
+	if len(prs) == 0 {
+		t.Fatal("No PRs found in test repository - this should not happen for goplus/llpkg")
+	}
+
+	pr := prs[0]
+	t.Logf("✅ GitHub PR Author Info:")
+	t.Logf("  Login: %s", pr.Author.Login)
+	t.Logf("  Name: %s", pr.Author.Name)
+	t.Logf("  Email: %s", pr.Author.Email)
+	t.Logf("  PR State: %s", pr.State)
+
+	// 验证至少有 Login 字段（这是必需的）
+	if pr.Author.Login == "" {
+		t.Error("Expected PR to have author login, but got empty string")
+	}
+
+	// Name 和 Email 可能为空，只记录不报错
+	if pr.Author.Name == "" {
+		t.Log("⚠️  Author Name is empty (this might be normal)")
+	}
+	if pr.Author.Email == "" {
+		t.Log("⚠️  Author Email is empty (this might be normal)")
+	}
+}
+
 // Helper function to check if string contains substring
 func contains(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -409,62 +409,66 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 
 	t.Logf("Total PRs fetched: %d", len(prs))
 
-	// 测试最旧的 22 个 PR（在数组末尾）
-	// 这 22 个 PR 中：1 个是 luoliwoshang (PR#58)，21 个是 xgopilot[bot]
-	// 按照从旧到新的顺序：PR#11, #12, #17, #18, ..., #57, #58
-	oldest22 := prs[len(prs)-22:]
+	// 反转数组，使其从旧到新排列，更直观
+	// 反转后：prs[0] = PR#11 (最旧), prs[21] = PR#58, ..., prs[78] = PR#158 (最新)
+	reversed := make([]models.PullRequest, len(prs))
+	for i, pr := range prs {
+		reversed[len(prs)-1-i] = pr
+	}
 
-	// 预期的作者（从旧到新）：最后一个是 luoliwoshang，前面 21 个是 bot
-	// 但在数组中，因为是倒序，所以第 0 个是 PR#58 (luoliwoshang)，后面是更旧的 bot PR
+	// 测试最旧的 22 个 PR（现在在数组开头）
+	// PR#11 到 PR#58（不连续）
+	// 前 21 个是 xgopilot[bot]，第 22 个（PR#58）是 luoliwoshang
+	oldest22 := reversed[:22]
+
 	expectedAuthors := []string{
-		"luoliwoshang", // prs[57] = PR#58 (最旧的第 22 个)
-		"xgopilot[bot]", // prs[58] = PR#57
-		"xgopilot[bot]", // prs[59] = PR#55
-		"xgopilot[bot]", // prs[60] = PR#53
-		"xgopilot[bot]", // prs[61] = PR#52
-		"xgopilot[bot]", // prs[62] = PR#51
-		"xgopilot[bot]", // prs[63] = PR#49
-		"xgopilot[bot]", // prs[64] = PR#47
-		"xgopilot[bot]", // prs[65] = PR#38
-		"xgopilot[bot]", // prs[66] = PR#33
-		"xgopilot[bot]", // prs[67] = PR#31
-		"xgopilot[bot]", // prs[68] = PR#29
-		"xgopilot[bot]", // prs[69] = PR#28
-		"xgopilot[bot]", // prs[70] = PR#27
-		"xgopilot[bot]", // prs[71] = PR#25
-		"xgopilot[bot]", // prs[72] = PR#23
-		"xgopilot[bot]", // prs[73] = PR#20
-		"xgopilot[bot]", // prs[74] = PR#19
-		"xgopilot[bot]", // prs[75] = PR#18
-		"xgopilot[bot]", // prs[76] = PR#17
-		"xgopilot[bot]", // prs[77] = PR#12
-		"xgopilot[bot]", // prs[78] = PR#11 (最旧的第 1 个)
+		"xgopilot[bot]",  // PR#11 (最旧)
+		"xgopilot[bot]",  // PR#12
+		"xgopilot[bot]",  // PR#17
+		"xgopilot[bot]",  // PR#18
+		"xgopilot[bot]",  // PR#19
+		"xgopilot[bot]",  // PR#20
+		"xgopilot[bot]",  // PR#23
+		"xgopilot[bot]",  // PR#25
+		"xgopilot[bot]",  // PR#27
+		"xgopilot[bot]",  // PR#28
+		"xgopilot[bot]",  // PR#29
+		"xgopilot[bot]",  // PR#31
+		"xgopilot[bot]",  // PR#33
+		"xgopilot[bot]",  // PR#38
+		"xgopilot[bot]",  // PR#47
+		"xgopilot[bot]",  // PR#49
+		"xgopilot[bot]",  // PR#51
+		"xgopilot[bot]",  // PR#52
+		"xgopilot[bot]",  // PR#53
+		"xgopilot[bot]",  // PR#55
+		"xgopilot[bot]",  // PR#57
+		"luoliwoshang",   // PR#58 (第 22 个最旧的)
 	}
 
 	for i, pr := range oldest22 {
-		globalIdx := len(prs) - 22 + i
 		expected := expectedAuthors[i]
 
 		// 验证作者 Login 匹配预期
 		if pr.Author.Login != expected {
-			t.Errorf("Index %d: Expected author to be %s, but got %s", globalIdx, expected, pr.Author.Login)
+			t.Errorf("PR #%d: Expected author to be %s, but got %s", i+1, expected, pr.Author.Login)
 		}
 
 		// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
 		if pr.Author.Name != "" {
-			t.Errorf("Index %d: Expected author name to be empty (GitHub API doesn't return it), but got %s", globalIdx, pr.Author.Name)
+			t.Errorf("PR #%d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i+1, pr.Author.Name)
 		}
 		if pr.Author.Email != "" {
-			t.Errorf("Index %d: Expected author email to be empty (GitHub API doesn't return it), but got %s", globalIdx, pr.Author.Email)
+			t.Errorf("PR #%d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i+1, pr.Author.Email)
 		}
 
 		// 验证 PR 状态
 		if pr.State == "" {
-			t.Errorf("Index %d: Expected PR to have a state, but got empty string", globalIdx)
+			t.Errorf("PR #%d: Expected PR to have a state, but got empty string", i+1)
 		}
 	}
 
-	t.Logf("✅ Verified 22 oldest PRs: 1 by luoliwoshang, 21 by xgopilot[bot]")
+	t.Logf("✅ Verified 22 oldest PRs (from oldest to newest): 21 by xgopilot[bot], 1 by luoliwoshang")
 }
 
 // Helper function to check if string contains substring

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -403,72 +403,125 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		t.Fatalf("Failed to get PR list: %v", err)
 	}
 
-	if len(prs) < 79 {
-		t.Fatalf("Expected at least 79 PRs, but got %d", len(prs))
+	if len(prs) != 79 {
+		t.Fatalf("Expected 79 PRs, but got %d", len(prs))
 	}
 
 	t.Logf("Total PRs fetched: %d", len(prs))
 
 	// 反转数组，使其从旧到新排列，更直观
-	// 反转后：prs[0] = PR#11 (最旧), prs[21] = PR#58, ..., prs[78] = PR#158 (最新)
 	reversed := make([]models.PullRequest, len(prs))
 	for i, pr := range prs {
 		reversed[len(prs)-1-i] = pr
 	}
 
-	// 测试最旧的 22 个 PR（现在在数组开头）
-	// PR#11 到 PR#58（不连续）
-	// 前 21 个是 xgopilot[bot]，第 22 个（PR#58）是 luoliwoshang
-	oldest22 := reversed[:22]
-
+	// 验证所有 79 个 PR 的作者信息（从旧到新的顺序）
+	// 包含 3 个真人用户：luoliwoshang (6个), MeteorsLiu (5个), 其余是 xgopilot[bot] (68个)
 	expectedAuthors := []string{
-		"xgopilot[bot]",  // PR#11 (最旧)
-		"xgopilot[bot]",  // PR#12
-		"xgopilot[bot]",  // PR#17
-		"xgopilot[bot]",  // PR#18
-		"xgopilot[bot]",  // PR#19
-		"xgopilot[bot]",  // PR#20
-		"xgopilot[bot]",  // PR#23
-		"xgopilot[bot]",  // PR#25
-		"xgopilot[bot]",  // PR#27
-		"xgopilot[bot]",  // PR#28
-		"xgopilot[bot]",  // PR#29
-		"xgopilot[bot]",  // PR#31
-		"xgopilot[bot]",  // PR#33
-		"xgopilot[bot]",  // PR#38
-		"xgopilot[bot]",  // PR#47
-		"xgopilot[bot]",  // PR#49
-		"xgopilot[bot]",  // PR#51
-		"xgopilot[bot]",  // PR#52
-		"xgopilot[bot]",  // PR#53
-		"xgopilot[bot]",  // PR#55
-		"xgopilot[bot]",  // PR#57
-		"luoliwoshang",   // PR#58 (第 22 个最旧的)
+		"xgopilot[bot]", // PR#11
+		"xgopilot[bot]", // PR#12
+		"xgopilot[bot]", // PR#17
+		"xgopilot[bot]", // PR#18
+		"xgopilot[bot]", // PR#19
+		"xgopilot[bot]", // PR#20
+		"xgopilot[bot]", // PR#23
+		"xgopilot[bot]", // PR#25
+		"xgopilot[bot]", // PR#27
+		"xgopilot[bot]", // PR#28
+		"xgopilot[bot]", // PR#29
+		"xgopilot[bot]", // PR#31
+		"xgopilot[bot]", // PR#33
+		"xgopilot[bot]", // PR#38
+		"xgopilot[bot]", // PR#47
+		"xgopilot[bot]", // PR#49
+		"xgopilot[bot]", // PR#51
+		"xgopilot[bot]", // PR#52
+		"xgopilot[bot]", // PR#53
+		"xgopilot[bot]", // PR#55
+		"xgopilot[bot]", // PR#57
+		"luoliwoshang",  // PR#58
+		"xgopilot[bot]", // PR#61
+		"xgopilot[bot]", // PR#62
+		"xgopilot[bot]", // PR#66
+		"xgopilot[bot]", // PR#67
+		"xgopilot[bot]", // PR#68
+		"xgopilot[bot]", // PR#70
+		"xgopilot[bot]", // PR#72
+		"xgopilot[bot]", // PR#74
+		"xgopilot[bot]", // PR#76
+		"xgopilot[bot]", // PR#78
+		"xgopilot[bot]", // PR#79
+		"xgopilot[bot]", // PR#80
+		"MeteorsLiu",    // PR#81
+		"xgopilot[bot]", // PR#83
+		"MeteorsLiu",    // PR#84
+		"xgopilot[bot]", // PR#85
+		"luoliwoshang",  // PR#86
+		"xgopilot[bot]", // PR#88
+		"luoliwoshang",  // PR#89
+		"xgopilot[bot]", // PR#91
+		"xgopilot[bot]", // PR#92
+		"xgopilot[bot]", // PR#94
+		"xgopilot[bot]", // PR#96
+		"xgopilot[bot]", // PR#98
+		"xgopilot[bot]", // PR#100
+		"xgopilot[bot]", // PR#101
+		"xgopilot[bot]", // PR#103
+		"luoliwoshang",  // PR#105
+		"luoliwoshang",  // PR#106
+		"luoliwoshang",  // PR#108
+		"xgopilot[bot]", // PR#112
+		"xgopilot[bot]", // PR#113
+		"xgopilot[bot]", // PR#120
+		"xgopilot[bot]", // PR#122
+		"xgopilot[bot]", // PR#124
+		"luoliwoshang",  // PR#125
+		"MeteorsLiu",    // PR#126
+		"xgopilot[bot]", // PR#129
+		"xgopilot[bot]", // PR#131
+		"MeteorsLiu",    // PR#132
+		"xgopilot[bot]", // PR#133
+		"xgopilot[bot]", // PR#134
+		"xgopilot[bot]", // PR#135
+		"xgopilot[bot]", // PR#137
+		"MeteorsLiu",    // PR#138
+		"xgopilot[bot]", // PR#139
+		"xgopilot[bot]", // PR#141
+		"xgopilot[bot]", // PR#143
+		"xgopilot[bot]", // PR#144
+		"xgopilot[bot]", // PR#146
+		"xgopilot[bot]", // PR#148
+		"xgopilot[bot]", // PR#150
+		"xgopilot[bot]", // PR#153
+		"xgopilot[bot]", // PR#155
+		"xgopilot[bot]", // PR#156
+		"xgopilot[bot]", // PR#157
+		"xgopilot[bot]", // PR#158
 	}
 
-	for i, pr := range oldest22 {
+	for i, pr := range reversed {
 		expected := expectedAuthors[i]
 
 		// 验证作者 Login 匹配预期
 		if pr.Author.Login != expected {
-			t.Errorf("PR #%d: Expected author to be %s, but got %s", i+1, expected, pr.Author.Login)
+			t.Errorf("PR index %d: Expected author to be %s, but got %s", i, expected, pr.Author.Login)
 		}
 
 		// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
 		if pr.Author.Name != "" {
-			t.Errorf("PR #%d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i+1, pr.Author.Name)
+			t.Errorf("PR index %d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Name)
 		}
 		if pr.Author.Email != "" {
-			t.Errorf("PR #%d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i+1, pr.Author.Email)
+			t.Errorf("PR index %d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Email)
 		}
 
 		// 验证 PR 状态
 		if pr.State == "" {
-			t.Errorf("PR #%d: Expected PR to have a state, but got empty string", i+1)
+			t.Errorf("PR index %d: Expected PR to have a state, but got empty string", i)
 		}
 	}
 
-	t.Logf("✅ Verified 22 oldest PRs (from oldest to newest): 21 by xgopilot[bot], 1 by luoliwoshang")
+	t.Logf("✅ Verified all 79 PRs (from oldest to newest): 68 by xgopilot[bot], 6 by luoliwoshang, 5 by MeteorsLiu")
 }
 
 // Helper function to check if string contains substring

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -420,12 +420,12 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		t.Errorf("Expected first PR author login to be %s, but got %s", expectedLogin, pr.Author.Login)
 	}
 
-	// GitHub PR 列表 API 通常不返回 Name 和 Email
+	// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
 	if pr.Author.Name != "" {
-		t.Logf("Note: Author Name is not empty: %s (GitHub API usually doesn't return this)", pr.Author.Name)
+		t.Errorf("Expected author name to be empty (GitHub API doesn't return it), but got %s", pr.Author.Name)
 	}
 	if pr.Author.Email != "" {
-		t.Logf("Note: Author Email is not empty: %s (GitHub API usually doesn't return this)", pr.Author.Email)
+		t.Errorf("Expected author email to be empty (GitHub API doesn't return it), but got %s", pr.Author.Email)
 	}
 
 	// 验证 PR 状态也被正确解析

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -403,8 +403,8 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		t.Fatalf("Failed to get PR list: %v", err)
 	}
 
-	if len(prs) != 79 {
-		t.Fatalf("Expected 79 PRs, but got %d", len(prs))
+	if len(prs) < 79 {
+		t.Fatalf("Expected at least 79 PRs, but got %d", len(prs))
 	}
 
 	t.Logf("Total PRs fetched: %d", len(prs))
@@ -415,8 +415,9 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		reversed[len(prs)-1-i] = pr
 	}
 
-	// 验证所有 79 个 PR 的作者信息（从旧到新的顺序）
+	// 验证最早的 79 个 PR 的作者信息（从旧到新的顺序）
 	// 包含 3 个真人用户：luoliwoshang (6个), MeteorsLiu (5个), 其余是 xgopilot[bot] (68个)
+	oldest79 := reversed[:79]
 	expectedAuthors := []string{
 		"xgopilot[bot]", // PR#11
 		"xgopilot[bot]", // PR#12
@@ -499,7 +500,7 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		"xgopilot[bot]", // PR#158
 	}
 
-	for i, pr := range reversed {
+	for i, pr := range oldest79 {
 		expected := expectedAuthors[i]
 
 		// 验证作者 Login 匹配预期
@@ -521,7 +522,7 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 		}
 	}
 
-	t.Logf("✅ Verified all 79 PRs (from oldest to newest): 68 by xgopilot[bot], 6 by luoliwoshang, 5 by MeteorsLiu")
+	t.Logf("✅ Verified first 79 PRs (from oldest): 68 by xgopilot[bot], 6 by luoliwoshang, 5 by MeteorsLiu")
 }
 
 // TestGitHubClient_GetPRList_AuthorInfo_HackathonGO 测试另一个仓库的 PR 作者信息解析
@@ -538,8 +539,8 @@ func TestGitHubClient_GetPRList_AuthorInfo_HackathonGO(t *testing.T) {
 		t.Fatalf("Failed to get PR list: %v", err)
 	}
 
-	if len(prs) != 48 {
-		t.Fatalf("Expected 48 PRs, but got %d", len(prs))
+	if len(prs) < 48 {
+		t.Fatalf("Expected at least 48 PRs, but got %d", len(prs))
 	}
 
 	t.Logf("Total PRs fetched: %d", len(prs))
@@ -550,8 +551,9 @@ func TestGitHubClient_GetPRList_AuthorInfo_HackathonGO(t *testing.T) {
 		reversed[len(prs)-1-i] = pr
 	}
 
-	// 验证所有 48 个 PR 的作者信息（从旧到新的顺序）
+	// 验证最早的 48 个 PR 的作者信息（从旧到新的顺序）
 	// 包含 4 个真人用户：CarlJi (15个), minorcell (13个), wwcchh0123 (6个), 其余是 xgopilot[bot] (14个)
+	oldest48 := reversed[:48]
 	expectedAuthors := []string{
 		"xgopilot[bot]", // PR#4
 		"minorcell",     // PR#5
@@ -603,7 +605,7 @@ func TestGitHubClient_GetPRList_AuthorInfo_HackathonGO(t *testing.T) {
 		"CarlJi",        // PR#68
 	}
 
-	for i, pr := range reversed {
+	for i, pr := range oldest48 {
 		expected := expectedAuthors[i]
 
 		// 验证作者 Login 匹配预期
@@ -625,7 +627,7 @@ func TestGitHubClient_GetPRList_AuthorInfo_HackathonGO(t *testing.T) {
 		}
 	}
 
-	t.Logf("✅ Verified all 48 PRs (from oldest to newest): 15 by CarlJi, 13 by minorcell, 6 by wwcchh0123, 14 by xgopilot[bot]")
+	t.Logf("✅ Verified first 48 PRs (from oldest): 15 by CarlJi, 13 by minorcell, 6 by wwcchh0123, 14 by xgopilot[bot]")
 }
 
 // Helper function to check if string contains substring

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -413,17 +413,24 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 	t.Logf("  Email: %s", pr.Author.Email)
 	t.Logf("  PR State: %s", pr.State)
 
-	// 验证至少有 Login 字段（这是必需的）
-	if pr.Author.Login == "" {
-		t.Error("Expected PR to have author login, but got empty string")
+	// 验证第一个 PR 的固定数据（基于当前 API 返回的真实数据）
+	// goplus/llpkg 的第一个 PR（按创建时间倒序）的作者是 aofei
+	expectedLogin := "aofei"
+	if pr.Author.Login != expectedLogin {
+		t.Errorf("Expected first PR author login to be %s, but got %s", expectedLogin, pr.Author.Login)
 	}
 
-	// Name 和 Email 可能为空，只记录不报错
-	if pr.Author.Name == "" {
-		t.Log("⚠️  Author Name is empty (this might be normal)")
+	// GitHub PR 列表 API 通常不返回 Name 和 Email
+	if pr.Author.Name != "" {
+		t.Logf("Note: Author Name is not empty: %s (GitHub API usually doesn't return this)", pr.Author.Name)
 	}
-	if pr.Author.Email == "" {
-		t.Log("⚠️  Author Email is empty (this might be normal)")
+	if pr.Author.Email != "" {
+		t.Logf("Note: Author Email is not empty: %s (GitHub API usually doesn't return this)", pr.Author.Email)
+	}
+
+	// 验证 PR 状态也被正确解析
+	if pr.State == "" {
+		t.Error("Expected PR to have a state, but got empty string")
 	}
 }
 

--- a/internal/api/github/client_test.go
+++ b/internal/api/github/client_test.go
@@ -394,44 +394,60 @@ func TestGitHubClient_GetPRList_AuthorInfo(t *testing.T) {
 	client := NewClient()
 	ctx := context.Background()
 
-	// 使用 goplus/llpkg - 一个中等规模的公开仓库
-	repo := "goplus/llpkg"
+	// 使用 luoliwoshang/prompt-front-overflow - 有 79 个 PR 的仓库
+	// 测试最早的 22 个 PR（按创建时间正序）
+	repo := "luoliwoshang/prompt-front-overflow"
 
 	prs, _, err := client.getPRList(ctx, repo, "")
 	if err != nil {
 		t.Fatalf("Failed to get PR list: %v", err)
 	}
 
-	if len(prs) == 0 {
-		t.Fatal("No PRs found in test repository - this should not happen for goplus/llpkg")
+	if len(prs) < 22 {
+		t.Fatalf("Expected at least 22 PRs, but got %d", len(prs))
 	}
 
-	pr := prs[0]
-	t.Logf("✅ GitHub PR Author Info:")
-	t.Logf("  Login: %s", pr.Author.Login)
-	t.Logf("  Name: %s", pr.Author.Name)
-	t.Logf("  Email: %s", pr.Author.Email)
-	t.Logf("  PR State: %s", pr.State)
-
-	// 验证第一个 PR 的固定数据（基于当前 API 返回的真实数据）
-	// goplus/llpkg 的第一个 PR（按创建时间倒序）的作者是 aofei
-	expectedLogin := "aofei"
-	if pr.Author.Login != expectedLogin {
-		t.Errorf("Expected first PR author login to be %s, but got %s", expectedLogin, pr.Author.Login)
+	// getPRList 按创建时间倒序返回（最新的在前）
+	// 所以 prs[len-22:] 是最早的 22 个 PR
+	startIdx := len(prs) - 22
+	if startIdx < 0 {
+		startIdx = 0
 	}
+	earliest22 := prs[startIdx:]
 
-	// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
-	if pr.Author.Name != "" {
-		t.Errorf("Expected author name to be empty (GitHub API doesn't return it), but got %s", pr.Author.Name)
-	}
-	if pr.Author.Email != "" {
-		t.Errorf("Expected author email to be empty (GitHub API doesn't return it), but got %s", pr.Author.Email)
+	t.Logf("Total PRs: %d, testing earliest 22 PRs (index %d to %d)", len(prs), startIdx, len(prs)-1)
+
+	// 验证最早的 22 个 PR 的作者信息
+	// 第一个是 luoliwoshang (PR#58)，后面 21 个都是 xgopilot[bot]
+	expectedAuthors := make([]string, 22)
+	expectedAuthors[0] = "luoliwoshang"
+	for i := 1; i < 22; i++ {
+		expectedAuthors[i] = "xgopilot[bot]"
 	}
 
-	// 验证 PR 状态也被正确解析
-	if pr.State == "" {
-		t.Error("Expected PR to have a state, but got empty string")
+	for i, pr := range earliest22 {
+		t.Logf("PR #%d Author: %s (expected: %s)", i, pr.Author.Login, expectedAuthors[i])
+
+		// 验证作者 Login 匹配预期
+		if pr.Author.Login != expectedAuthors[i] {
+			t.Errorf("PR #%d: Expected author login to be %s, but got %s", i, expectedAuthors[i], pr.Author.Login)
+		}
+
+		// GitHub PR 列表 API 不返回 Name 和 Email，应该为空
+		if pr.Author.Name != "" {
+			t.Errorf("PR #%d: Expected author name to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Name)
+		}
+		if pr.Author.Email != "" {
+			t.Errorf("PR #%d: Expected author email to be empty (GitHub API doesn't return it), but got %s", i, pr.Author.Email)
+		}
+
+		// 验证 PR 状态
+		if pr.State == "" {
+			t.Errorf("PR #%d: Expected PR to have a state, but got empty string", i)
+		}
 	}
+
+	t.Logf("✅ Verified 22 earliest PRs: 1 by luoliwoshang, 21 by xgopilot[bot]")
 }
 
 // Helper function to check if string contains substring

--- a/internal/models/repository.go
+++ b/internal/models/repository.go
@@ -20,6 +20,18 @@ const (
 type PullRequest struct {
 	// State PR 状态：open, closed, merged
 	State PRState
+	// Author PR 作者信息
+	Author Author
+}
+
+// Author 代表作者信息
+type Author struct {
+	// Login 用户名
+	Login string
+	// Name 显示名称（可能为空）
+	Name string
+	// Email 邮箱地址（可能为空）
+	Email string
 }
 
 // PRStats PR 统计信息


### PR DESCRIPTION
## Summary
为 PullRequest 数据结构添加作者信息支持，解决 Issue #13

## 主要更改

### 1. 数据模型更新 (`internal/models/repository.go`)
- 在 `PullRequest` 结构体中添加 `Author` 字段
- 新增 `Author` 结构体，包含以下字段：
  - `Login`: 用户名（必需）
  - `Name`: 显示名称（可选）
  - `Email`: 邮箱地址（可选）

### 2. GitHub Client 更新 (`internal/api/github/client.go`)
- 在 `getPRList` 方法中添加作者信息解析
- 从 API 响应的 `user` 字段中提取 `login`、`name`、`email`

### 3. Gitee Client 更新 (`internal/api/gitee/client.go`)
- 在 `getPRList` 方法中添加作者信息解析
- 从 API 响应的 `user` 字段中提取 `login`、`name`、`email`

### 4. 测试覆盖
- 添加 `TestGitHubClient_GetPRList_AuthorInfo` 测试
- 添加 `TestGiteeClient_GetPRList_AuthorInfo` 测试
- 验证作者信息能够正确解析

## 测试结果

### GitHub API
```
✅ GitHub PR Author Info:
  Login: aofei
  Name: 
  Email: 
  PR State: merged
```
- **Login**: ✓ 成功获取
- **Name/Email**: GitHub PR 列表 API 通常不返回这些字段，为空是正常的

### Gitee API
```
✅ Gitee PR Author Info:
  Login: guzitao
  Name: guzitao
  Email: 
  PR State: merged
```
- **Login**: ✓ 成功获取
- **Name**: ✓ 成功获取
- **Email**: Gitee PR 列表 API 通常不返回此字段，为空是正常的

## Test Plan
- [x] 运行 GitHub client 测试 - 通过
- [x] 运行 Gitee client 测试 - 通过
- [x] 验证至少能获取到 Login 字段
- [x] 确认 Name 和 Email 为空不会导致错误

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)